### PR TITLE
Fixed NoneType Error

### DIFF
--- a/ghostwriter/modules/reportwriter.py
+++ b/ghostwriter/modules/reportwriter.py
@@ -94,7 +94,12 @@ def strip_html(s):
     ``s``
         String of HTML text to strip down
     """
-    html = BeautifulSoup(s, "lxml")
+    
+    try:
+        html = BeautifulSoup(s, "lxml")
+    except:
+        return
+    
     output = ""
     for tag in html.descendants:
         if isinstance(tag, str):


### PR DESCRIPTION
Fixed error: "NoneType has no object len()" when trying to generate a report with findings that do not have all fields filled in.